### PR TITLE
AreaDataCenter: Remove redundant parent field

### DIFF
--- a/aoirint_jmapy/api.py
+++ b/aoirint_jmapy/api.py
@@ -10,7 +10,6 @@ class AreaDataCenter(BaseModel):
   name: str
   enName: str
   officeName: str
-  parent: Optional[str]
   children: List[str]
 
 class AreaDataClass20s(BaseModel):


### PR DESCRIPTION
AreaDataCenter型に実際には存在しない、`parent`フィールドが存在するため削除します。