### PR TITLE
WarningDataTimeSeriesItemAreaWarningWave: remove redundant Union

### DIFF
--- a/aoirint_jmapy/api.py
+++ b/aoirint_jmapy/api.py
@@ -262,7 +262,7 @@ class WarningDataTimeSeriesItemAreaWarningWind(BaseModel):
 class WarningDataTimeSeriesItemAreaWarningWave(BaseModel):
   code: str
   levels: List[WarningDataTimeSeriesItemAreaWarningLevelWave]
-  properties: Optional[List[Union[WarningDataTimeSeriesItemAreaWarningWindPropertyWaveHeight]]]
+  properties: Optional[List[WarningDataTimeSeriesItemAreaWarningWindPropertyWaveHeight]]
 
 WarningDataTimeSeriesItemAreaWarning = Union[WarningDataTimeSeriesItemAreaWarningWind, WarningDataTimeSeriesItemAreaWarningLightning, WarningDataTimeSeriesItemAreaWarningWave]
 


### PR DESCRIPTION
WarningDataTimeSeriesItemAreaWarningWaveに冗長なUnion型が存在するため、Union型でなくします。